### PR TITLE
Add github resource

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -1,7 +1,25 @@
 -- | Main bot executable
 module Main where
 
+import           Airship
+import qualified Bot.Github               as Github
+import           Network.Wai.Handler.Warp (defaultSettings, runSettings,
+                                           setHost, setPort)
 import           Prelude
 
+routes :: RoutingSpec s IO ()
+routes = "github" #> Github.resource
+
+notFound :: Resource s m
+notFound = defaultResource
+    { resourceExists       = return False
+    , contentTypesProvided = return [("application/json", return Empty)]
+    }
+
 main :: IO ()
-main = undefined
+main = do
+    let port = 3000
+        host = "127.0.0.1"
+        settings = setPort port (setHost host defaultSettings)
+    putStrLn "Listening on port 3000"
+    runSettings settings (resourceToWai routes notFound undefined)

--- a/bot.cabal
+++ b/bot.cabal
@@ -18,107 +18,119 @@ flag documentation
   default: False
 
 library
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    exposed-modules:  Bot
-    hs-source-dirs:   src
-    build-depends:    airship >= 0.3 && < 1,
-                      base >= 4 && < 5,
-                      bytestring,
-                      http-types >= 0.7,
-                      mtl,
-                      securemem,
-                      SHA,
-                      text,
-                      void >= 0.7
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude,
+                        OverloadedStrings,
+                        FlexibleContexts,
+                        ImpredicativeTypes
+    exposed-modules:    Bot, Bot.Github, Bot.Internal
+    hs-source-dirs:     src
+    build-depends:      airship >= 0.3 && < 1,
+                        base >= 4 && < 5,
+                        bytestring,
+                        http-media,
+                        http-types >= 0.7,
+                        mtl,
+                        securemem,
+                        SHA,
+                        text,
+                        transformers >= 0.3 && < 1,
+                        void >= 0.7
 
   if flag(documentation)
     build-depends: hscolour >= 1.22
 
 executable bot
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    main-is:          Main.hs
-    hs-source-dirs:   bin
-    build-depends:    airship >= 0.3 && < 1,
-                      base >= 4 && < 5,
-                      bot,
-                      void >= 0.7,
-                      wai == 3.0.2.*,
-                      warp == 3.0.*
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude,
+                        OverloadedStrings
+    main-is:            Main.hs
+    hs-source-dirs:     bin
+    build-depends:      airship >= 0.3 && < 1,
+                        base >= 4 && < 5,
+                        bot,
+                        void >= 0.7,
+                        wai == 3.0.2.*,
+                        warp == 3.0.*
 
 test-suite hspec
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    main-is:          Spec.hs
-    hs-source-dirs:   spec src
-    type:             exitcode-stdio-1.0
-    build-depends:    base,
-                      bot,
-                      hspec >= 2.1
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    main-is:            Spec.hs
+    hs-source-dirs:     spec src
+    type:               exitcode-stdio-1.0
+    build-depends:      base,
+                        bot,
+                        hspec >= 2.1
 
 test-suite hlint
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    hs-source-dirs:   spec
-    main-is:          HLint.hs
-    type:             exitcode-stdio-1.0
-    build-depends:    base,
-                      Glob,
-                      hlint >= 1.9
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    hs-source-dirs:     spec
+    main-is:            HLint.hs
+    type:               exitcode-stdio-1.0
+    build-depends:      base,
+                        Glob,
+                        hlint >= 1.9
 
 test-suite doctest
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    hs-source-dirs:   spec
-    main-is:          DocTest.hs
-    type:             exitcode-stdio-1.0
-    build-depends:    base,
-                      Glob,
-                      doctest >= 0.9
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    hs-source-dirs:     spec
+    main-is:            DocTest.hs
+    type:               exitcode-stdio-1.0
+    build-depends:      base,
+                        Glob,
+                        doctest >= 0.9
 
 test-suite haddock
-    ghc-options:      -Wall
-                      -Werror
-                      -fwarn-incomplete-record-updates
-                      -fwarn-tabs
-                      -fwarn-monomorphism-restriction
-                      -fwarn-unused-do-bind
-                      -fwarn-implicit-prelude
-    default-language: Haskell2010
-    hs-source-dirs:   spec
-    main-is:          Haddock.hs
-    type:             exitcode-stdio-1.0
-    build-depends:    base,
-                      process >= 1.2,
-                      regex-compat >= 0.95
+    ghc-options:        -Wall
+                        -Werror
+                        -fwarn-incomplete-record-updates
+                        -fwarn-tabs
+                        -fwarn-monomorphism-restriction
+                        -fwarn-unused-do-bind
+                        -fwarn-implicit-prelude
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    hs-source-dirs:     spec
+    main-is:            Haddock.hs
+    type:               exitcode-stdio-1.0
+    build-depends:      base,
+                        process >= 1.2,
+                        regex-compat >= 0.95

--- a/spec/Spec.hs
+++ b/spec/Spec.hs
@@ -1,2 +1,1 @@
 {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
-{-# LANGUAGE NoImplicitPrelude #-}

--- a/src/Bot/Github.hs
+++ b/src/Bot/Github.hs
@@ -1,0 +1,63 @@
+-- | Github Resource module
+module Bot.Github (resource) where
+
+import           Airship
+import           Bot.Internal
+import qualified Data.ByteString.Lazy as LB
+import           Data.Int             (Int64)
+import           Data.Maybe           (fromJust)
+import           Network.HTTP.Media   (MediaType, mapContentMedia)
+import qualified Network.HTTP.Types   as HTTP
+import           Prelude
+
+maximumPayloadSize :: Int64
+maximumPayloadSize = 1048576  -- 1MB
+
+-- | Github resource
+resource :: Resource s IO
+resource = defaultResource
+    { allowedMethods       = return [HTTP.methodPost]
+    , malformedRequest     = testRequest
+    , forbidden            = testSignatureHeader
+    , entityTooLarge       = testPayloadSize
+    , knownContentType     = contentTypeMatches (fmap fst accepted)
+    , processPost          = return (PostProcess negotiatePostHandler)
+    , contentTypesProvided = return [("application/json", return Empty)]
+    }
+
+-- | Accepted media types
+accepted :: [(MediaType, Handler s m ())]
+accepted = [("application/json", pushEvent)]
+
+-- | Test the event header
+testRequest :: Handler s m Bool
+testRequest = testHeader "X-GitHub-Event" (== "push")
+
+-- | Test the signature header
+testSignatureHeader :: Handler s IO Bool
+testSignatureHeader = do
+    payload <- requestPayload
+    testHeader "X-Hub-Signature" (verifySignature hmacKey payload)
+  where
+    hmacKey = "secret"  -- TODO: make this configurable
+
+-- | Test the request payload size
+testPayloadSize :: Handler s IO Bool
+testPayloadSize = do
+    payload <- requestPayload
+    return $ LB.length payload > maximumPayloadSize
+
+-- | Negotiate the request handler
+negotiatePostHandler :: Handler s m ()
+negotiatePostHandler = do
+    req <- request
+    let postHandler = fromJust $ do
+            cType <- lookup HTTP.hContentType (requestHeaders req)
+            mapContentMedia accepted cType
+    postHandler
+
+-- | Handle push event
+pushEvent :: Handler s m ()
+pushEvent = do
+    addResponseHeader ("Push-Event", "True")  -- XXX: DEBUG
+    return ()

--- a/src/Bot/Internal.hs
+++ b/src/Bot/Internal.hs
@@ -1,0 +1,39 @@
+-- | Bot internal module
+module Bot.Internal
+    ( verifySignature
+    , testHeader
+    , requestPayload) where
+
+import           Airship
+import           Control.Monad.IO.Class (liftIO)
+import           Data.ByteString        as B
+import           Data.ByteString.Char8  as B8
+import qualified Data.ByteString.Lazy   as LB
+import qualified Data.Digest.Pure.SHA   as SHA
+import           Data.SecureMem
+import qualified Network.HTTP.Types     as HTTP
+import           Prelude
+
+-- | Verify the HMAC of the text and key
+verifySignature :: LB.ByteString -> LB.ByteString -> B.ByteString -> Bool
+verifySignature key text = secureCompare expected
+  where
+    expected = B8.pack ("sha1=" ++ SHA.showDigest (SHA.hmacSha1 key text))
+
+-- | Secure constant time comparison
+secureCompare :: (ToSecureMem a, ToSecureMem b) => a -> b -> Bool
+secureCompare a b = toSecureMem a == toSecureMem b
+
+-- | Test request header if it exists
+testHeader :: HTTP.HeaderName -> (B.ByteString -> Bool) -> Handler s m Bool
+testHeader name test = do
+    req <- request
+    case lookup name $ requestHeaders req of
+        Nothing    -> return True
+        Just value -> return $ not $ test value
+
+-- | Request payload
+requestPayload :: Handler s IO LB.ByteString
+requestPayload = do
+    req <- request
+    liftIO (entireRequestBody req)


### PR DESCRIPTION
This branch adds a github resource. It will receive all push notifications from github, log them to a database and (in a future PR) trigger a build.
### TODO
- [ ] Add endpoint to receive Github webhook push notifications
  - [x] Test the `X-Hub-Signature` (signature) header is valid
    - [x] Return 403 if not valid
  - [x] Test the message body size
    - [x] Return 413 if message body is too large
  - [x] Test the `X-Github-Event` (the event type) header is supported
    - [x] Return 400 if the event type is not supported
  - [ ] Test if the request body is valid JSON
    - [ ] Return 400 if the body is _syntactically invalid_ JSON
  - [ ] Parse the request body with aeson
    - [ ] Store the raw request headers and body in a database (for logging/replay)
    - [ ] Return 422 if the body  is _semantically invalid_ JSON
  - [ ] Create a record to represent the commit state
    - [ ] Store the `X-Github-Delivery` (request id) as a UUID
